### PR TITLE
change subject param in interface message to topic to common term

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -13,9 +13,9 @@ var (
 
 type CloudEventStream interface {
 	Publish(ctx context.Context, ev event.Event) error
-	Subscribe(subject, group string, handler func(msg *event.Event, ctx context.Context) error) error
-	SubscribeDLQ(subject string, handler func(msg any, ctx context.Context) error) error
-	CreateStream(stream string, subjects []string) error
+	Subscribe(topic, group string, handler func(msg *event.Event, ctx context.Context) error) error
+	SubscribeDLQ(topic string, handler func(msg any, ctx context.Context) error) error
+	CreateStream(stream string, topics []string) error
 	CreateConsumerGroup(stream, name string, config ConsumerConfig) error
 	Close() error
 }


### PR DESCRIPTION
As we discussion for common the messaging interface, currently we target to support redis stream and nats stream, then we want to change the param name subject to topic in all methods used